### PR TITLE
Support retrieval of SSL certificate/key pair

### DIFF
--- a/files/docker/run_graylogctl
+++ b/files/docker/run_graylogctl
@@ -30,10 +30,14 @@ else
         graylog-ctl local-connect && graylog-ctl reconfigure
 fi
 if [ ! -z "$GRAYLOG_SSL_CERTIFICATE_URL"]; then
-        curl -o "/opt/graylog/conf/nginx/ca/graylog.crt" "$GRAYLOG_SSL_CERTIFICATE_URL"
+        curl -o "/tmp/graylog.crt" "$GRAYLOG_SSL_CERTIFICATE_URL" && \
+        mv -f "/opt/graylog/conf/nginx/ca/graylog.crt" "/opt/graylog/conf/nginx/ca/graylog.crt.old" && \
+        mv -f "/tmp/graylog.crt" "/opt/graylog/conf/nginx/ca/graylog.crt"
 fi
 if [ ! -z "$GRAYLOG_SSL_PRIVATEKEY_URL"]; then
-        curl -o "/opt/graylog/conf/nginx/ca/graylog.key" "$GRAYLOG_SSL_PRIVATEKEY_URL"
+        curl -o "/tmp/graylog.key" "$GRAYLOG_SSL_PRIVATEKEY_URL" && \
+        mv -f "/opt/graylog/conf/nginx/ca/graylog.key" "/opt/graylog/conf/nginx/ca/graylog.key.old" && \
+        mv -f "/tmp/graylog.key" "/opt/graylog/conf/nginx/ca/graylog.key"
 fi
 if [ -f "/opt/graylog/conf/nginx/ca/graylog.crt" ] && [ -f "/opt/graylog/conf/nginx/ca/graylog.key" ]; then
         graylog-ctl restart nginx

--- a/files/docker/run_graylogctl
+++ b/files/docker/run_graylogctl
@@ -29,3 +29,12 @@ elif [ ! -z "$GRAYLOG_SERVER" ]; then
 else
         graylog-ctl local-connect && graylog-ctl reconfigure
 fi
+if [ ! -z "$GRAYLOG_SSL_CERTIFICATE_URL"]; then
+        curl -o "/opt/graylog/conf/nginx/ca/graylog.crt" "$GRAYLOG_SSL_CERTIFICATE_URL"
+fi
+if [ ! -z "$GRAYLOG_SSL_PRIVATEKEY_URL"]; then
+        curl -o "/opt/graylog/conf/nginx/ca/graylog.key" "$GRAYLOG_SSL_PRIVATEKEY_URL"
+fi
+if [ -f "/opt/graylog/conf/nginx/ca/graylog.crt" ] && [ -f "/opt/graylog/conf/nginx/ca/graylog.key" ]; then
+        graylog-ctl restart nginx
+fi

--- a/files/docker/run_graylogctl
+++ b/files/docker/run_graylogctl
@@ -32,13 +32,15 @@ fi
 if [ ! -z "$GRAYLOG_SSL_CERTIFICATE_URL"]; then
         curl -o "/tmp/graylog.crt" "$GRAYLOG_SSL_CERTIFICATE_URL" && \
         mv -f "/opt/graylog/conf/nginx/ca/graylog.crt" "/opt/graylog/conf/nginx/ca/graylog.crt.old" && \
-        mv -f "/tmp/graylog.crt" "/opt/graylog/conf/nginx/ca/graylog.crt"
+        mv -f "/tmp/graylog.crt" "/opt/graylog/conf/nginx/ca/graylog.crt" && \
+        GRAYLOG_SSL_CERTIFICATE_UPDATED=true
 fi
 if [ ! -z "$GRAYLOG_SSL_PRIVATEKEY_URL"]; then
         curl -o "/tmp/graylog.key" "$GRAYLOG_SSL_PRIVATEKEY_URL" && \
         mv -f "/opt/graylog/conf/nginx/ca/graylog.key" "/opt/graylog/conf/nginx/ca/graylog.key.old" && \
-        mv -f "/tmp/graylog.key" "/opt/graylog/conf/nginx/ca/graylog.key"
+        mv -f "/tmp/graylog.key" "/opt/graylog/conf/nginx/ca/graylog.key" && \
+        GRAYLOG_SSL_PRIVATEKEY_UPDATED=true
 fi
-if [ -f "/opt/graylog/conf/nginx/ca/graylog.crt" ] && [ -f "/opt/graylog/conf/nginx/ca/graylog.key" ]; then
+if [ -z "$GRAYLOG_SSL_CERTIFICATE_UPDATED" ] && [ -z "$GRAYLOG_SSL_PRIVATEKEY_UPDATED" ]; then
         graylog-ctl restart nginx
 fi


### PR DESCRIPTION
Use built-in Graylog SSL functionality to support native SSL. 

Provide URLs to both GRAYLOG_SSL_CERTIFICATE_URL and GRAYLOG_SSL_PRIVATEKEY_URL environment variables to have certificate and key retrieved by curl, placed on filesystem, and nginx restarted once done.
