### PR TITLE
graylog-server shoudn't add elasticsearch node.

### DIFF
--- a/files/graylog-cookbooks/graylog/recipes/graylog-server.rb
+++ b/files/graylog-cookbooks/graylog/recipes/graylog-server.rb
@@ -80,6 +80,5 @@ ruby_block "add node to server list" do
   block do
     $registry.set_master
     $registry.add_gl_server(node['ipaddress'])
-    $registry.add_es_node(node['ipaddress'])
   end
 end


### PR DESCRIPTION
This is done by elasticsearch recipe.
