### PR TITLE
Mark Omnibus package as conflicting regular DEB package

### DIFF
--- a/config/projects/graylog-beta.rb
+++ b/config/projects/graylog-beta.rb
@@ -6,6 +6,8 @@ install_dir     '/opt/graylog'
 build_version   '2.2.0-rc.1'
 build_iteration  1
 
+conflict 'graylog-server'
+
 override :ruby,       version: "2.1.10",
                         source: { md5: "c212fdeed9534ec7cb9bf13c0bf4d1d5" }
 override :'chef-gem', version: "12.6.0"

--- a/config/projects/graylog.rb
+++ b/config/projects/graylog.rb
@@ -6,6 +6,8 @@ install_dir     '/opt/graylog'
 build_version   '2.2.3'
 build_iteration  1
 
+conflict 'graylog-server'
+
 override :ruby,       version: "2.1.10",
                         source: { md5: "c212fdeed9534ec7cb9bf13c0bf4d1d5" }
 override :'chef-gem', version: "12.6.0"


### PR DESCRIPTION
Every now and then people try to "upgrade" the Graylog OVA (using the Graylog Omnibus package) using the regular DEB packages (latest example: https://community.graylog.org/t/upgrade-from-2-2-2-to-2-2-3-still-remain-old-version/760).

This PR adds the regular Graylog DEB package ("graylog-server") to the list of conflicting packages so that the users will at least receive a more comprehensible error message.

Refs Graylog2/fpm-recipes#77